### PR TITLE
utf8: cast ‘in’ pointer to iconv()

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -59,7 +59,7 @@ iconv_code_conv(iconv_t cd, const char *instr)
     out = outbuf;
     outs = outbufsiz;
 
-    ret = iconv(cd, &in, &ins, &out, &outs);
+    ret = iconv(cd, (char **)&in, &ins, &out, &outs);
     nconv = outbufsiz - outs;
     if (ret == (size_t)-1) {
       switch (errno) {


### PR DESCRIPTION
This fixes an “incompatible pointer type” warning: the `inbuf` argument is supposed to be a `char **`, while the ‘in’ variable is `const char **`:

```
../../utf8.c: In function ‘iconv_code_conv’:
../../utf8.c:62:21: warning: passing argument 2 of ‘iconv’ from incompatible pointer type [-Wincompatible-pointer-types]
   62 |     ret = iconv(cd, &in, &ins, &out, &outs);
      |                     ^~~
      |                     |
      |                     const char **
```