### PR TITLE
main: define _POSIX_C_SOURCE to 200809

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 2
+#define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
`strdup()` needs `_POSIX_C_SOURCE` >= `200809`, not >= `2`:

```
   Feature Test Macro Requirements for glibc (see feature_test_macros(7)):

       strdup():
           _XOPEN_SOURCE >= 500
               || /* Since glibc 2.12: */ _POSIX_C_SOURCE >= 200809L
               || /* Glibc versions <= 2.19: */ _BSD_SOURCE || _SVID_SOURCE
```